### PR TITLE
Fix conflict with Arduino's Serial (Pin 0)

### DIFF
--- a/LightSound_code_v1.5.0/LightSound_code_v1.5.0.ino
+++ b/LightSound_code_v1.5.0/LightSound_code_v1.5.0.ino
@@ -101,7 +101,7 @@ int nwaitHigh = 200;
 /**************************************************************************/
 // lux sensor setup
 Adafruit_TSL2591 tsl = Adafruit_TSL2591(2591); // TSL2591 Lux sensor
-SoftwareSerial VS1053_MIDI(0, VS1053_RX); //MIDI board; TX only, do not use the 'rx' side
+SoftwareSerial VS1053_MIDI(4, VS1053_RX); //MIDI board; TX only, do not use the 'rx' side. Set RX to any unused pin
 
 /**************************************************************************/
 // define setup loop


### PR DESCRIPTION
SoftwareSerial was previously defined to use digital pin 0, conflicting with Arduino's hardware serial.
This can cause some boards to be unusable until reprogrammed via ICSP header (or any other failsafe method depending on the board) due serial being inaccessible (USB port is also connected to serial pins 0 and 1).

Is not recommended to use these pins in any way for this reason, so changing to pin 4 as default.